### PR TITLE
Adds a rate-limited BlockChainInfoQueue

### DIFF
--- a/custom_components/cryptoportfolio/BTCPortfolioSensor.py
+++ b/custom_components/cryptoportfolio/BTCPortfolioSensor.py
@@ -1,17 +1,21 @@
 import requests
+import logging
+
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.components.sensor import SensorEntity
 
 ATTRIBUTION = "Data provided by blockchain.info"
 
+_LOGGER = logging.getLogger(__name__)
 
 class BTCPortfolioSensor(SensorEntity):
     """Representation of an CryptoPortfolio sensor."""
 
-    def __init__(self, name, address):
+    def __init__(self, name, address, queue):
         """Initialize the sensor."""
         self._name = name
         self._address = address
+        self._queue = queue
         self._decimals = 8
         self._state = None
         self._unit_of_measurement = "BTC"
@@ -41,7 +45,18 @@ class BTCPortfolioSensor(SensorEntity):
         return {ATTR_ATTRIBUTION: ATTRIBUTION}
 
     def update(self):
+        """Queues a request to update the latest state of the sensor."""
+        self._queue.addRequest(self)
+
+    def execute(self):
         """Get the latest state of the sensor."""
+        _LOGGER.debug(f"Getting BTC balance for {self._address}")
+
         r = requests.get(url=f"https://blockchain.info/q/addressbalance/{self._address}")
+
+        if r.status_code == 429:
+            _LOGGER.warning(f"blockchain.info is reporting a 429 Too Many Requests response")
+            return
+
         data = r.json()
         self._state = int(data) / (10 ** self._decimals)

--- a/custom_components/cryptoportfolio/BlockChainInfoQueue.py
+++ b/custom_components/cryptoportfolio/BlockChainInfoQueue.py
@@ -1,0 +1,32 @@
+import logging
+import queue
+import threading
+
+_LOGGER = logging.getLogger(__name__)
+
+# https://blockchain.info/api/q
+# The API requests: Please limit your queries to a maximum of 1 every 10 seconds
+# Aim for up to one call every 15 seconds to be safe
+RATE_LIMIT = 15
+
+class BlockChainInfoQueue():
+    def __init__(self):
+        self._queue = queue.Queue()        
+
+        # check for new work every RATE_LIMIT seconds
+        threading.Timer(RATE_LIMIT, self.processQueue).start()
+
+    def addRequest(self, sensor):
+        _LOGGER.debug(f"Queueing an update for {sensor.name}")
+        self._queue.put(sensor)
+
+    def processQueue(self):
+        _LOGGER.debug(f"Checking queue: {self._queue.qsize()} entries")
+
+        threading.Timer(RATE_LIMIT, self.processQueue).start()
+
+        if self._queue.empty():
+            return
+
+        task = self._queue.get()
+        task.execute()

--- a/custom_components/cryptoportfolio/sensor.py
+++ b/custom_components/cryptoportfolio/sensor.py
@@ -12,11 +12,15 @@ from .constants import CONF_ADDRESS, CONF_NAME, CONF_TOKEN, CONF_TOKEN_ADDRESS, 
     CONF_EXPLORER_API_KEY, CONF_DECIMALS, CONF_BLOCKCHAIN, SUPPORTED_BLOCKCHAINS, SUPPORTED_BLOCKCHAIN_ETHORFORK, SUPPORTED_BLOCKCHAIN_BTC
 from .ETHorForkPortfolioSensor import ETHorForkPortfolioSensor
 from .BTCPortfolioSensor import BTCPortfolioSensor
+from .BlockChainInfoQueue import BlockChainInfoQueue
+
 import homeassistant.helpers.config_validation as cv
 
 SCAN_INTERVAL = timedelta(minutes=5)
 
 _LOGGER = logging.getLogger(__name__)
+
+blockChainInfoQueue = BlockChainInfoQueue()
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -80,7 +84,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if not name:
             name = "BTC Balance"
 
-        add_entities([BTCPortfolioSensor(name, address)], True)
+        add_entities([BTCPortfolioSensor(name, address, blockChainInfoQueue)], True)
 
 
     else:


### PR DESCRIPTION
Hi!

I was seeing some issues with 429 responses from blockchain.info's API, probably because I have a decent amount of addresses being monitored.

This adds a `BlockChainInfoQueue.py` which does one API call every 15 seconds max (blockchain.info's [documentation](https://www.blockchain.com/api/q) requests one call every 10 seconds max).

First time writing python, so apologies if I've missed anything obvious.