### PR TITLE
Change to Etherscan v2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this to your `configuration.yaml`.
 - token_address (if not provided, then main coin is used, e.g. ETH, BNB)
 - explorer_api_key
 - main_coin (default: `ETH`)
-- explorer_api_url (default: `https://api.etherscan.io/api`)
+- explorer_api_url (default: `https://api.etherscan.io/v2/api?chainid=1`)
 - decimals (default: `18`)
 - blockchain (default: `ETH_OR_FORK`)
 

--- a/custom_components/cryptoportfolio/sensor.py
+++ b/custom_components/cryptoportfolio/sensor.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_TOKEN): cv.string,
         vol.Optional(CONF_TOKEN_ADDRESS): cv.string,
-        vol.Optional(CONF_EXPLORER_API_URL, default="https://api.etherscan.io/api"): cv.string,
+        vol.Optional(CONF_EXPLORER_API_URL, default="https://api.etherscan.io/v2/api?chainid=1"): cv.string,
         vol.Optional(CONF_MAIN_COIN, default="ETH"): cv.string,
         vol.Optional(CONF_DECIMALS, default=18): cv.positive_int,
         vol.Optional(CONF_EXPLORER_API_KEY): cv.string,
@@ -60,7 +60,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         if not explorer_api_url or not main_coin:
             """Default blockchain"""
-            explorer_api_url = "https://api.etherscan.io/api"
+            explorer_api_url = "https://api.etherscan.io/v2/api?chainid=1"
             main_coin = "ETH"
 
         main_coin = main_coin.upper()


### PR DESCRIPTION
Fix for https://github.com/wsdt/sensor.cryptoportfolio/issues/4

Switches to Etherscan v2 API per the [migration guide](https://docs.etherscan.io/etherscan-v2/v2-quickstart).

The mainnet `chainid=1` is hard-coded ([other chains here](https://api.etherscan.io/v2/chainlist)) but this could be changed by changing the `explorer_api_url ` per sensor.